### PR TITLE
Inject sinon sandbox in the current module before the QUnit module's setup()` method is invoked.

### DIFF
--- a/jsTestDriver.conf
+++ b/jsTestDriver.conf
@@ -6,6 +6,9 @@ load:
   - deps/sinon/lib/sinon/stub.js
   - deps/sinon/lib/sinon/assert.js
   - deps/sinon/lib/sinon/test.js
+  - deps/sinon/lib/sinon/sandbox.js
+  - deps/sinon/lib/sinon/match.js
+  - deps/sinon/lib/sinon/util/fake_timers.js
   - test/fake_qunit.js
   - lib/*.js
   - test/helper.js

--- a/lib/sinon-qunit.js
+++ b/lib/sinon-qunit.js
@@ -17,13 +17,57 @@ sinon.config = {
 
 (function (global) {
     var qTest = QUnit.test;
-    
+    var activeSandbox = null;
+
+    var runTestInSandbox = function (test) {
+        return function () {
+            var exception, result;
+            var args = Array.prototype.slice.call(arguments).concat(activeSandbox.args);
+
+            if (sinon.config.useFakeTimers) {
+                global.setTimeout = activeSandbox.clock.setTimeout;
+            }
+
+            try {
+                result = test.apply(this, args);
+            } catch (e) {
+                exception = e;
+            }
+
+            if (typeof exception !== "undefined") {
+                activeSandbox.restore();
+                throw exception;
+            }
+            else {
+                activeSandbox.verifyAndRestore();
+            }
+
+            return result;
+        };
+    };
+
+    QUnit.testStart(function () {
+        var sandboxConfig = sinon.getConfig(sinon.config);
+        sandboxConfig.injectInto = QUnit.config.current.testEnvironment;
+
+        activeSandbox = sinon.sandbox.create(sandboxConfig);
+
+        // Restore the native setTimeout method as it's used internally by QUnit.
+        if (sinon.config.useFakeTimers) {
+            global.setTimeout = sinon.timers.setTimeout;
+        }
+    });
+
+    QUnit.testDone(function () {
+        activeSandbox = null;
+    });
+
     QUnit.test = global.test = function (testName, expected, callback, async) {
         if (arguments.length === 2) {
             callback = expected;
             expected = null;
         }
 
-        return qTest(testName, expected, sinon.test(callback), async);
+        return qTest(testName, expected, runTestInSandbox(callback), async);
     };
 }(this));

--- a/test/fake_qunit.js
+++ b/test/fake_qunit.js
@@ -2,8 +2,13 @@
 var QUnit = {
     ok: function () {},
     test: sinon.spy(),
-    testStart: sinon.spy(),
-    testDone: sinon.spy()
+	module: sinon.spy(),
+    testStart: sinon.stub(),
+    testDone: sinon.stub(),
+	config: {
+		current: {}
+	}
 };
 
 QUnit.originalTest = QUnit.test;
+QUnit.originalSetTimeout = window.setTimeout;

--- a/test/fake_qunit.js
+++ b/test/fake_qunit.js
@@ -1,7 +1,9 @@
 /*global sinon*/
 var QUnit = {
     ok: function () {},
-    test: sinon.spy()
+    test: sinon.spy(),
+    testStart: sinon.spy(),
+    testDone: sinon.spy()
 };
 
 QUnit.originalTest = QUnit.test;

--- a/test/sinon-qunit-test.js
+++ b/test/sinon-qunit-test.js
@@ -3,12 +3,13 @@
 testCase("SinonQUnitTest", {
     setUp: function () {
         sinon.spy(QUnit, "ok");
+		sinon.stub(sinon.sandbox, "create");
     },
 
     tearDown: function () {
-        if (sinon.test.restore) {
-            sinon.test.restore();
-        }
+		if (sinon.sandbox.create.restore) {
+			sinon.sandbox.create.restore();
+		}
 
         QUnit.originalTest.callCount = 0;
         QUnit.originalTest.args = [];
@@ -29,55 +30,59 @@ testCase("SinonQUnitTest", {
         assert(QUnit.ok.calledWithExactly(true, "calledOnce"));
     },
 
-    "should pass callback to sinon.test": function () {
-        sinon.spy(sinon, "test");
-        var func = function () {};
-        test("Test", func);
-
-        assert(sinon.test.calledOnce);
-        assert(sinon.test.calledWith(func));
-    },
-
-    "should pass name and sandboxed callback to QUnit": function () {
-        var sandboxed = function () {};
-        sinon.stub(sinon, "test").returns(sandboxed);
+    "should pass name and test runner callback to QUnit": function () {
         QUnit.test("Test", function () {});
 
         assert(QUnit.originalTest.calledOnce);
-        assert(QUnit.originalTest.calledWith("Test", null, sandboxed, undefined));
+        assert(QUnit.originalTest.calledWith("Test", null, sinon.match.func, undefined));
     },
 
-    "should pass name, expected and sandboxed callback to QUnit": function () {
-        var sandboxed = function () {};
-        sinon.stub(sinon, "test").returns(sandboxed);
+    "should pass name, expected and test runner callback to QUnit": function () {
         QUnit.test("Test This", 23, function () {});
 
-        assert(QUnit.originalTest.calledWith("Test This", 23, sandboxed, undefined));
+        assert(QUnit.originalTest.calledWith("Test This", 23, sinon.match.func, undefined));
     },
 
-    "should pass name, env and sandboxed callback to QUnit": function () {
-        var sandboxed = function () {};
+    "should pass name, env and test runner callback to QUnit": function () {
         var env = { id: 42 };
-        sinon.stub(sinon, "test").returns(sandboxed);
         QUnit.test("Test This", env, function () {});
 
-        assert(QUnit.originalTest.calledWith("Test This", env, sandboxed, undefined));
+        assert(QUnit.originalTest.calledWith("Test This", env, sinon.match.func, undefined));
     },
 
-    "should pass name, env, sandboxed callback and async to QUnit": function () {
-        var sandboxed = function () {};
+    "should pass name, env, test runner callback and async to QUnit": function () {
         var env = { id: 42 };
-        sinon.stub(sinon, "test").returns(sandboxed);
         QUnit.test("Test This", env, function () {}, true);
 
-        assert(QUnit.originalTest.calledWith("Test This", env, sandboxed, true));
+        assert(QUnit.originalTest.calledWith("Test This", env, sinon.match.func, true));
     },
 
-    "should pass name, expected, sandboxed callback and async to QUnit": function () {
-        var sandboxed = function () {};
-        sinon.stub(sinon, "test").returns(sandboxed);
+    "should pass name, expected, test runner callback and async to QUnit": function () {
         QUnit.test("Test This", 42, function () {}, true);
 
-        assert(QUnit.originalTest.calledWith("Test This", 42, sandboxed, true));
-    }
+        assert(QUnit.originalTest.calledWith("Test This", 42, sinon.match.func, true));
+    },
+	
+	"Callback registered against QUnit.testStart should create a sinon sandbox with the expected `injectInto` property": function () {
+		var createSandbox = QUnit.testStart.firstCall.args[0];
+		QUnit.config.current.testEnvironment = {};
+
+		createSandbox();
+
+		assert(sinon.sandbox.create.calledWithMatch({
+			injectInto: QUnit.config.current.testEnvironment
+		}));
+	},
+
+	"Global setTimeout() is restored when the sandbox is created if `sinon.config.useFakeTimers` to ensure QUnit can still run": function ()
+	{
+		var createSandbox = QUnit.testStart.firstCall.args[0];
+		sinon.config.useFakeTimers = true;
+
+		// Sinon will stub setTimeout, but QUnit needs it to work!
+		window.setTimeout = function () {};
+		createSandbox();
+
+		assert(window.setTimeout === sinon.timers.setTimeout);
+	}
 });

--- a/test/sinon-qunit-test.js
+++ b/test/sinon-qunit-test.js
@@ -3,13 +3,13 @@
 testCase("SinonQUnitTest", {
     setUp: function () {
         sinon.spy(QUnit, "ok");
-		sinon.stub(sinon.sandbox, "create");
+        sinon.stub(sinon.sandbox, "create");
     },
 
     tearDown: function () {
-		if (sinon.sandbox.create.restore) {
-			sinon.sandbox.create.restore();
-		}
+        if (sinon.sandbox.create.restore) {
+            sinon.sandbox.create.restore();
+        }
 
         QUnit.originalTest.callCount = 0;
         QUnit.originalTest.args = [];
@@ -62,27 +62,27 @@ testCase("SinonQUnitTest", {
 
         assert(QUnit.originalTest.calledWith("Test This", 42, sinon.match.func, true));
     },
-	
-	"Callback registered against QUnit.testStart should create a sinon sandbox with the expected `injectInto` property": function () {
-		var createSandbox = QUnit.testStart.firstCall.args[0];
-		QUnit.config.current.testEnvironment = {};
 
-		createSandbox();
+    "Callback registered against QUnit.testStart should create a sinon sandbox with the expected `injectInto` property": function () {
+        var createSandbox = QUnit.testStart.firstCall.args[0];
+        QUnit.config.current.testEnvironment = {};
 
-		assert(sinon.sandbox.create.calledWithMatch({
-			injectInto: QUnit.config.current.testEnvironment
-		}));
-	},
+        createSandbox();
 
-	"Global setTimeout() is restored when the sandbox is created if `sinon.config.useFakeTimers` to ensure QUnit can still run": function ()
-	{
-		var createSandbox = QUnit.testStart.firstCall.args[0];
-		sinon.config.useFakeTimers = true;
+        assert(sinon.sandbox.create.calledWithMatch({
+            injectInto: QUnit.config.current.testEnvironment
+        }));
+    },
 
-		// Sinon will stub setTimeout, but QUnit needs it to work!
-		window.setTimeout = function () {};
-		createSandbox();
+    "Global setTimeout() is restored when the sandbox is created if `sinon.config.useFakeTimers` to ensure QUnit can still run": function ()
+    {
+        var createSandbox = QUnit.testStart.firstCall.args[0];
+        sinon.config.useFakeTimers = true;
 
-		assert(window.setTimeout === sinon.timers.setTimeout);
-	}
+        // Sinon will stub setTimeout, but QUnit needs it to work!
+        window.setTimeout = function () {};
+        createSandbox();
+
+        assert(window.setTimeout === sinon.timers.setTimeout);
+    }
 });


### PR DESCRIPTION
This allows the developer to initiate their stubs, mocks and spies in the setup method, safe in the knowledge that they will be automatically reset between each test.

I had trouble getting the jsTestDriver unit tests to work (and wasn't 100% sure what coverage I should be adding!)
