### PR TITLE
sinon.expectation.fail does not delegate to sinon.assert.fail

### DIFF
--- a/lib/sinon-qunit.js
+++ b/lib/sinon-qunit.js
@@ -1,5 +1,5 @@
 /*global sinon, QUnit, test*/
-sinon.assert.fail = function (msg) {
+sinon.expectation.fail = sinon.assert.fail = function (msg) {
     QUnit.ok(false, msg);
 };
 


### PR DESCRIPTION
Set up sinon's expectations to fail with QUnit's ok.
