### PR TITLE
Fixing test.callback is null error

### DIFF
--- a/lib/sinon-qunit.js
+++ b/lib/sinon-qunit.js
@@ -1,10 +1,10 @@
 /*global sinon, QUnit, test*/
 sinon.expectation.fail = sinon.assert.fail = function (msg) {
-    QUnit.ok(false, msg);
+    QUnit.assert.ok(false, msg);
 };
 
 sinon.assert.pass = function (assertion) {
-    QUnit.ok(true, assertion);
+    QUnit.assert.ok(true, assertion);
 };
 
 sinon.config = {
@@ -21,9 +21,8 @@ sinon.config = {
     QUnit.test = global.test = function (testName, expected, callback, async) {
         if (arguments.length === 2) {
             callback = expected;
-            expected = null;
+            return qTest(testName, sinon.test(callback), async);
         }
-
         return qTest(testName, expected, sinon.test(callback), async);
     };
 }(this));


### PR DESCRIPTION
Encountered an error in qunit-2.1.1.js:1054 when running tests.

line > promise = test.callback.call(test.testEnvironment, test.assert);
error > test.callback is null

Using
sinon-1.17.6.js
sinon-ie-1.17.6.js
sinon-qunit-1.0.0.js